### PR TITLE
USB sync to drive: enhanced services_start / services_stop scripts to…

### DIFF
--- a/lib/services_start.php
+++ b/lib/services_start.php
@@ -1,35 +1,59 @@
-<?php if ($config['remotebuzzer_enabled']):
-	$connection = @fsockopen('127.0.0.1', $config['remotebuzzer_port']);
+<?php
 
-	if (! is_resource($connection))
-	{
-		if ($config['dev'])
-		{
-			$logfile = $config['folders']['tmp']."/".$config['remotebuzzer_logfile'];
-		}
-		else
-		{ $logfile = "/dev/null"; }
+require_once(__DIR__ . '/config.php');
 
-		print ("\t<!-- Remote Buzzer Enabled --- starting server -->\n");
+function processIsRunning ($pName, $pidFile) {
+        if (file_exists($pidFile))
+        {
+                exec("pgrep -F ".$pidFile, $output, $return);
+                if ($return == 0) { return true; } // process is active
+                unlink ($pidFile); // remove stale PID file
+        }
 
-		proc_close(proc_open ($config['nodebin']['cmd']." resources/js/remotebuzzer_server.js 1>>".$logfile." 2>&1 &", array(), $foo));
+        exec("pgrep -a -f ".$pName, $output, $return);
+        return count($output)-1 ? true : false ; // true if process is active
+}
 
-	} else {
-	       print ("\t<!-- Remote Buzzer Enabled --- server already started (port in use) -->\n");
-	}
 
-?>
-<script type="text/javascript" src="node_modules/socket.io-client/dist/socket.io.slim.js"></script>
+if ($config['remotebuzzer_enabled']) {
+        $connection = @fsockopen('127.0.0.1', $config['remotebuzzer_port']);
 
-<?php endif;
+        if (! is_resource($connection))
+        {
+                if ($config['dev'])
+                {
+                        $logfile = $config['foldersAbs']['tmp']."/".$config['remotebuzzer_logfile'];
+                }
+                else
+                { $logfile = "/dev/null"; }
 
-    if ($config['synctodrive_enabled'] && !file_exists($config['folders']['tmp'].'/synctodrive_server.pid') {
-      	if ($config['dev']) {
-	      $logfile = $config['folders']['tmp']."/".$config['synctodrive_logfile'];
-		}
-		else { $logfile = "/dev/null"; }
-		
-		print ("\t<!-- Sync To Drive enabled --- starting server -->\n");
-		proc_close(proc_open ($config['nodebin']['cmd']." resources/js/sync-to-drive.js 1>>".$logfile." 2>&1 &", array(), $foo));
-	}
+                print ("\t<!-- Remote Buzzer enabled --- starting server -->\n");
+
+                proc_close(proc_open ($config['nodebin']['cmd']." resources/js/remotebuzzer_server.js 1>>".$logfile." 2>&1 &", array(), $foo));
+
+        } else {
+               print ("\t<!-- Remote Buzzer Enabled --- server already started (port in use) -->\n");
+        }
+
+        print("\t<script type=\"text/javascript\" src=\"node_modules/socket.io-client/dist/socket.io.slim.js\"></script>\n");
+}
+
+if ($config['synctodrive_enabled']) {
+            if ($config['dev']) {
+                 $logfile = $config['foldersAbs']['tmp']."/".$config['synctodrive_logfile'];
+            }
+            else {
+                 $logfile = "/dev/null";
+            }
+
+            if ( processIsRunning("sync-to-drive.js",$config['foldersAbs']['tmp'].'/synctodrive_server.pid'))
+            {
+               print ("\t<!-- Sync To Drive enabled --- server already active -->\n");
+            }
+            else
+            {
+               print ("\t<!-- Sync To Drive enabled --- starting server -->\n");
+               proc_close(proc_open ($config['nodebin']['cmd']." resources/js/sync-to-drive.js 1>>".$logfile." 2>&1 &", array(), $foo));
+            }
+}
 ?>

--- a/lib/services_stop.php
+++ b/lib/services_stop.php
@@ -5,48 +5,29 @@ require_once(__DIR__ . '/config.php');
 
 function killProcessIfActive($pName, $pidFile, $logfileName)
 {
-	global $config;
+        global $config;
 
-	if (file_exists($pidFile))
-	{
-		$myfile = fopen($pidFile, "r");
-		$procPID = fread($myfile,100);
-		fclose($myfile);
+        exec("pgrep -f ".$pName,$pids);
 
-		posix_kill($procPID, 9);
+        if (count($pids) > 1) {
+           foreach ($pids as $procPID) {
+                if ($config['dev'])
+                {
+                        $logfile = $config['foldersAbs']['tmp']."/".$logfileName;
+                        $fp = fopen($logfile, 'a');//opens file in append mode.
+                        fwrite($fp, "Service Control [ config ]: Photobooth config has changed, killed processes by name ".$pName." -> PID ".$procPID."\n");
+                        fclose($fp);
+                }
 
-		unlink ($pidFile);
+                posix_kill($procPID, 9);
+           }
+        }
 
-		if ($config['dev'])
-		{
-			$logfile = $config['folders']['tmp']."/".$logfileName;
-			$fp = fopen("../".$logfile, 'a');//opens file in append mode.
-			fwrite($fp, "Service Control [ config ]: Photobooth config has changed, kill existing $pName process (PID ".$procPID.") and remove PID file\n");
-			fclose($fp);
-		}
-	}
-	else
-	{
-		exec("pgrep -f ".$pName,$pids);
+        if (file_exists($pidFile)) { unlink ($pidFile); }
 
-		if (count($pids) > 1) {
-		   foreach ($pids as $procPID) {
-		   	if ($config['dev'])
-			{	
-				$logfile = $config['folders']['tmp']."/".$logfileName;
-				$fp = fopen("../".$logfile, 'a');//opens file in append mode.
-				fwrite($fp, "Service Control [ config ]: Photobooth config has changed, killed processes by name ".$pName." -> ".$procPID."\n");
-				fclose($fp);
-			}
-
-			posix_kill($procPID, 9);
-		   }
-		}
-
-	}
 }
-
 
 killProcessIfActive('remotebuzzer_server.js','../'.$config['folders']['tmp'].'/remotebuzzer_server.pid',$config['remotebuzzer_logfile']);
 killProcessIfActive('sync-to-drive.js','../'.$config['folders']['tmp'].'/synctodrive_server.pid',$config['synctodrive_logfile']);
+
 ?>

--- a/src/js/sync-to-drive.js
+++ b/src/js/sync-to-drive.js
@@ -182,7 +182,7 @@ const isProcessRunning = (processName) => {
 
 const writePIDFile = (filename) => {
     try {
-        fs.writeFileSync(filename, PID, {mode: 'wx'});
+        fs.writeFileSync(filename, PID, {flag: 'w'});
         log(`PID file created [${filename}]`);
     } catch (err) {
         throw new Error(`Unable to write PID file [${filename}] - ${err.message}`);


### PR DESCRIPTION
... be more robust.

Thanks for checking. How could I miss that - I think I actually never tested the core use-case of taking a picture *omg*. I did some additions to not only check for the PID file as such but have the script be a bit more robust - both before starting service but also when stopping services. 

And one small tweak in sync-to-drive.js ---- when writing the PID to file, I believe it was meant to be 'flags' instead of 'mode'. And I would prefer mode of 'w' to overwrite an existing, possibly stale log file. 'wx' would force the process to exit when the file exists. but eventually not the actual process itself. 

[https://github.com/andi34/photobooth/pull/115](https://github.com/andi34/photobooth/pull/115)
